### PR TITLE
Fix a few broken links in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,11 @@ and a precompiled wasm ready for deployment called `contract.wasm`.
 
 Take a look here:
 
-* [escrow](https://github.com/CosmWasm/cw-examples/tree/main/contracts/escrow) - A basic escrow with timeout and partial release
-* [erc20](https://github.com/CosmWasm/cw-examples/tree/main/contracts/erc20) - Basic implementation the erc20 interface for CosmWasm, as a base for token designers
-* [nameservice](https://github.com/CosmWasm/cw-examples/tree/main/contracts/nameservice) - Simple name service application to buy names and map values to those names
-* [voting](https://github.com/CosmWasm/cw-examples/tree/main/contracts/voting) - An example voting contract to create, manage, vote and deposit on polls
-* [simple-option](https://github.com/CosmWasm/cw-examples/tree/main/contracts/simple-option) - A contract that replicates options in finance
-* [cw20-pot](https://github.com/CosmWasm/cw-examples/tree/main/contracts/cw20-pot) - Basic smart contract using cw20 contact
+* [escrow](https://github.com/InterWasm/cw-contracts/tree/main/contracts/escrow) - A basic escrow with timeout and partial release
+* [nameservice](https://github.com/InterWasm/cw-contracts/tree/main/contracts/nameservice) - Simple name service application to buy names and map values to those names
+* [voting](https://github.com/InterWasm/cw-contracts/tree/main/contracts/voting) - An example voting contract to create, manage, vote and deposit on polls
+* [simple-option](https://github.com/InterWasm/cw-contracts/tree/main/contracts/simple-option) - A contract that replicates options in finance
+* [cw20-pot](https://github.com/InterWasm/cw-contracts/tree/main/contracts/cw20-pot) - Basic smart contract using cw20 contact
 
 You can get more info from `README.md` file in each of the contacts.
 

--- a/contracts/escrow/Cargo.toml
+++ b/contracts/escrow/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 license = "Apache-2.0"
 description = "Simple CosmWasm contract for an escrow with arbiter and timeout"
-repository = "https://github.com/CosmWasm/cosmwasm-examples"
+repository = "https://github.com/InterWasm/cw-contracts"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/contracts/escrow/Publishing.md
+++ b/contracts/escrow/Publishing.md
@@ -16,7 +16,7 @@ You will want entries like the following in `Cargo.toml`:
 name = "cw-escrow"
 version = "0.1.0"
 description = "Simple CosmWasm contract for an escrow with arbiter and timeout"
-repository = "https://github.com/CosmWasm/cosmwasm-examples"
+repository = "https://github.com/InterWasm/cw-contracts"
 ```
 
 You will also want to add a valid [SPDX license statement](https://spdx.org/licenses/),

--- a/contracts/escrow/README.md
+++ b/contracts/escrow/README.md
@@ -26,5 +26,5 @@ to the world, once you are ready to deploy it on a running blockchain. And
 [Importing](./Importing.md) contains information about pulling in other contracts or crates
 that have been published.
 
-But more than anything, there is an [online tutorial](https://www.cosmwasm.com/docs/getting-started/intro),
+But more than anything, there is an [online tutorial](https://docs.cosmwasm.com/tutorials/hijack-escrow/hack-contract#a-walk-through-of-the-escrow-contract),
 which leads you step-by-step on how to modify this particular contract.

--- a/contracts/nameservice/Cargo.toml
+++ b/contracts/nameservice/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.11.0"
 authors = ["Cory Levinson <cjlevinson@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"
-repository = "https://github.com/CosmWasm/cosmwasm-examples"
+repository = "https://github.com/InterWasm/cw-contracts"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/contracts/nameservice/README.md
+++ b/contracts/nameservice/README.md
@@ -1,9 +1,7 @@
 # Name Service
 
-This is a CosmWasm derivation of [Cosmos SDK's name service application](https://tutorials.cosmos.network/nameservice/tutorial/01-app-design.html)
-
 The goal of the application you are building is to let users buy names and to set a value these names resolve to.
 The owner of a given name will be the current highest bidder. In this section, you will learn how these simple
  requirements translate to application design.
 
-Here is the tutorial for this application: [tutorial](https://docs.cosmwasm.com/0.14/learn/name-service/intro.html)
+Here is the tutorial for this application: [tutorial](https://docs.cosmwasm.com/tutorials/name-service/intro)

--- a/contracts/simple-option/README.md
+++ b/contracts/simple-option/README.md
@@ -1,3 +1,3 @@
 # Simple Option
 
-Tutorial: https://docs.cosmwasm.com/0.14/learn/simple-option/intro.html
+Tutorial: https://docs.cosmwasm.com/tutorials/simple-option/intro

--- a/contracts/voting/Cargo.toml
+++ b/contracts/voting/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Taariq Levack <levackt@users.noreply.github.com>"]
 edition = "2018"
 license = "Apache-2.0"
 description = "Simple CosmWasm contract for voting"
-repository = "https://github.com/CosmWasm/cosmwasm-examples"
+repository = "https://github.com/InterWasm/cw-contracts"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
In the process of learning about CosmWasm, I spotted a couple broken links in the READMEs for these examples:

- simple-option
- nameservice
- escrow

I also remove a line in nameservice that was linking to a resource that didn't appear to be there anymore. (I searched around the site https://tutorials.cosmos.network and looked for a replacement, but I think it's been removed.

Update: a couple more commits fixing or updating other links